### PR TITLE
CI-453 -> Sorting on UKPRN

### DIFF
--- a/src/Sfa.Roatp.Indexer.Infrastructure/Elasticsearch/ElasticsearchProviderIndexMaintainer.cs
+++ b/src/Sfa.Roatp.Indexer.Infrastructure/Elasticsearch/ElasticsearchProviderIndexMaintainer.cs
@@ -43,7 +43,12 @@ namespace Sfa.Roatp.Indexer.Infrastructure.Elasticsearch
                         .NumberOfShards(_elasticsearchConfiguration.RoatpProviderIndexShards())
                         .NumberOfReplicas(_elasticsearchConfiguration.RoatpProviderIndexReplicas()))
                     .Mappings(ms => ms
-                        .Map<RoatpProviderDocument>(m => m.AutoMap())));
+                        .Map<RoatpProviderDocument>(m => m
+                            .AutoMap()
+                            .Properties(p => p
+                                .Text(t => t
+                                    .Name(n => n.Ukprn).Fielddata()))
+                        ) ));
 
             if (response.ApiCall.HttpStatusCode != (int)HttpStatusCode.OK)
             {


### PR DESCRIPTION
* Added fielddata=true for ukprn (currently Text field) so we can easily sort on that when searching

Hi, 
Please discuss.
After upgrading the indexer and then the the ROATP register to use ES5 I get an error when searching the ROATP index. 
`Type: illegal_argument_exception Reason: "Fielddata is disabled on text fields by default. Set fielddata=true on [ukprn]`
It seems to be because the field UKPRN is of type TEXT and operations like sorting do not seem to be supported for text field by default. [ES - Fielddata](https://www.elastic.co/guide/en/elasticsearch/reference/5.0/fielddata.html#fielddata)


Ideally we would probably like to index the UKRPN as a number (long in most places) and if we don't have any reason not doing that I suggest we create a story?

For now to get this thing working we could apply this mapping when creating then index?

ta.